### PR TITLE
Fix: Persist your session on client-side page refresh

### DIFF
--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -37,6 +37,16 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 				if (res.status != 200) {
 					throw new Error("Failed to refresh token");
 				}
+				const currentUser = res.data.data?.user;
+				if (currentUser) {
+					setUser(currentUser);
+					localStorage.setItem("user", JSON.stringify(currentUser));
+				} else {
+					console.warn(
+						"User data not found in current-user response, logging out."
+					);
+					logout(); // Clear session if user data is missing
+				}
 			} catch (err) {
 				console.warn("Session refresh failed", err);
 				logout(); // Ensure session is clean if refresh fails
@@ -45,10 +55,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 			}
 		};
 
-		const storedUser = localStorage.getItem("user");
-		if (storedUser) {
-			setUser(JSON.parse(storedUser));
-		}
+		// Comment out or remove the local storage check before initializeAuth
+		// const storedUser = localStorage.getItem("user");
+		// if (storedUser) {
+		// 	setUser(JSON.parse(storedUser));
+		// }
 
 		initializeAuth();
 	}, []);


### PR DESCRIPTION
The primary issue was that the client-side authentication context (`AuthContext.tsx`) was not correctly utilizing the response from the `/current-user` endpoint during its initialization logic (`initializeAuth`). While it made the API call, it didn't use the returned user data to set the application's auth state or update localStorage if the call was successful.

This commit addresses the issue by:
1. Modifying `client/src/contexts/AuthContext.tsx`:
    - The `initializeAuth` function now extracts user data from a successful `/current-user` API response.
    - This data is used to update the React user state via `setUser()`.
    - The received user data is also persisted to `localStorage`.
    - Removed pre-emptive loading from localStorage before `initializeAuth` to ensure `initializeAuth` is the single source of truth for the initial user state.

I verified that server-side configurations for the `/current-user` and `/logout` routes correctly apply the `verifyAccessToken` middleware, ensuring that token verification and refresh logic are triggered as expected.